### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -100,3 +100,7 @@ information, see [Authentication page](http://docs.travis-ci.com/api/#authentica
 
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
+
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`

--- a/actions/cancel_build.yaml
+++ b/actions/cancel_build.yaml
@@ -1,5 +1,5 @@
 name: cancel_build
-runner_type: run-python
+runner_type: python-script
 description: Cancel a build.
 enabled: true
 entry_point: cancel_build.py

--- a/actions/disable_hook.yaml
+++ b/actions/disable_hook.yaml
@@ -1,5 +1,5 @@
 name: disable_hook
-runner_type: run-python
+runner_type: python-script
 description: Disable hooks for a git repo.
 enabled: true
 entry_point: disable_hook.py

--- a/actions/enable_hook.yaml
+++ b/actions/enable_hook.yaml
@@ -1,5 +1,5 @@
 name: enable_hook
-runner_type: run-python
+runner_type: python-script
 description: Enable hook for a git repo.
 enabled: true
 entry_point: enable_hook.py

--- a/actions/get_repo.yaml
+++ b/actions/get_repo.yaml
@@ -1,5 +1,5 @@
 name: get_repo
-runner_type: run-python
+runner_type: python-script
 description: Retrieve details for a provided repository.
 enabled: true
 entry_point: get_repo.py

--- a/actions/list_branches.yaml
+++ b/actions/list_branches.yaml
@@ -1,5 +1,5 @@
 name: list_branches
-runner_type: run-python
+runner_type: python-script
 description: List all branches for a given repository.
 enabled: true
 entry_point: list_branches.py

--- a/actions/list_builds.yaml
+++ b/actions/list_builds.yaml
@@ -1,5 +1,5 @@
 name: list_builds
-runner_type: run-python
+runner_type: python-script
 description: List details of all the available builds.
 enabled: true
 entry_point: list_builds.py

--- a/actions/list_hooks.yaml
+++ b/actions/list_hooks.yaml
@@ -1,5 +1,5 @@
 name: list_hooks
-runner_type: run-python
+runner_type: python-script
 description: List available hooks for the authenticated user.
 enabled: true
 entry_point: list_hooks.py

--- a/actions/list_repos.yaml
+++ b/actions/list_repos.yaml
@@ -1,5 +1,5 @@
 name: list_repos
-runner_type: run-python
+runner_type: python-script
 description: List repositories for the provided user.
 enabled: true
 entry_point: list_repos.py

--- a/actions/restart_build.yaml
+++ b/actions/restart_build.yaml
@@ -1,5 +1,5 @@
 name: restart_build
-runner_type: run-python
+runner_type: python-script
 description: Restart a Build
 enabled: true
 entry_point: restart_build.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
  - travis ci
  - continuous integration
  - ci
-version: 0.2.0
+version: 0.3.0
 author: Aamir
 email: raza.aamir01@gmail.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.